### PR TITLE
Change default user for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,6 +236,7 @@ jobs:
       #
       #    # note: I tested this locally with *only* the homebrew postgres server running and it worked.
       #    # no idea why this does not work on github actions
+      #    # Edit: It seems homebrew postgresql does not create the postgres user automatically.
       #    - name: Run test suite
       #      run: |
       #        brew services start postgresql
@@ -273,6 +274,13 @@ jobs:
         conda install -y -c anaconda postgresql
         initdb -D test_db
         pg_ctl -D test_db -o "-d 5" start  # start with debugging
+
+    - name: Create postgres superuser on Windows
+      if: matrix.os == 'windows-2019'
+      shell: bash -l {0}
+      run: |
+        createuser -s postgres
+        createuser -s runneradmin
 
     - name: Install pgsu
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,12 +275,11 @@ jobs:
         initdb -D test_db
         pg_ctl -D test_db -o "-d 5" start  # start with debugging
 
-    - name: Create postgres superuser on Windows
-      if: matrix.os == 'windows-2019'
-      shell: bash -l {0}
-      run: |
-        createuser -U runneradmin -s postgres
-        createuser -U runneradmin -s runneradmin
+    # - name: Create postgres superuser on Windows
+    #   if: matrix.os == 'windows-2019'
+    #   shell: bash -l {0}
+    #   run: |
+    #     createuser -U runneradmin -s postgres
 
     - name: Install pgsu
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,8 +279,8 @@ jobs:
       if: matrix.os == 'windows-2019'
       shell: bash -l {0}
       run: |
-        createuser -s postgres
-        createuser -s runneradmin
+        createuser -U runneradmin -s postgres
+        createuser -U runneradmin -s runneradmin
 
     - name: Install pgsu
       run: |

--- a/pgsu/__init__.py
+++ b/pgsu/__init__.py
@@ -6,20 +6,10 @@
 import logging
 import traceback
 import os
-import platform
 from enum import IntEnum
 import subprocess
 
 import click
-
-DEFAULT_DSN = {
-    'host':
-    None,  # 'localhost' causes psql to connect via method 'host' instead of 'local'
-    'port': 5432,
-    'user': 'postgres',
-    'password': None,
-    'database': 'template1',
-}
 
 # By default, try "sudo" only when 'postgres' user exists
 DEFAULT_POSTGRES_UNIX_USER = 'postgres'
@@ -30,6 +20,19 @@ try:
 except (KeyError, ModuleNotFoundError):
     # user not found or pwd module not found (=not Unix)
     DEFAULT_TRY_SUDO = False
+
+DEFAULT_POSTGRES_SUPERUSER = 'postgres'
+if os.name == 'nt':  # on windows
+    DEFAULT_POSTGRES_SUPERUSER = os.getlogin()
+
+DEFAULT_DSN = {
+    'host':
+    None,  # 'localhost' causes psql to connect via method 'host' instead of 'local'
+    'port': 5432,
+    'user': DEFAULT_POSTGRES_SUPERUSER,
+    'password': None,
+    'database': 'template1',
+}
 
 LOGGER = logging.getLogger('pgsu')
 LOGGER.setLevel(logging.DEBUG)


### PR DESCRIPTION
It seems that [somewhere between April 5th 2020 and February 17th 2021](https://github.com/aiidateam/pgsu/issues/22), on the Github Action Windows runners the default superuser of postgresql databases changed.
The superuser created upon installation of the postgresql conda package used to be `postgres` like on UNIX systems, but then started to use the name of the OS user running the commands (here: `runneradmin`),  seemingly without updating the postgresql conda package.

This change switches the default database superuser for Windows from `postgres` to the OS user, fixing CI tests.