### PR TITLE
fix: change directory for sudo route

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,7 +253,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8]
-        os: ['macos-10.15', 'windows-2019']
+        os: ['macos-12', 'windows-2019']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Install python dependencies
       run: |
-        pip install -e .[pre-commit,testing]
+        pip install -e .[pre_commit,testing]
         pip freeze
 
     - name: Run pre-commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
 
     - name: Install python dependencies
       run: |
-        pip install --upgrade pip
         pip install -e .[pre-commit,testing]
         pip freeze
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
 
     - name: Install python dependencies
       run: |
-        pip install -e .[pre_commit,testing]
+        pip install --upgrade pip
+        pip install -e .[pre-commit,testing]
         pip freeze
 
     - name: Run pre-commit
@@ -245,7 +246,7 @@ jobs:
 
 
   multi-conda:
-    # windows with postgres installed via conda (+pgtest)
+    # windows and macos with postgres installed via conda (+pgtest)
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5
@@ -265,7 +266,6 @@ jobs:
 
     - uses: conda-incubator/setup-miniconda@v2
       with:
-        # auto-update-conda: true
         python-version: ${{ matrix.python-version }}
 
     - name: Install system dependencies

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ In order to create them, you will need to connect to PostgreSQL as a SUPERUSER.
    * [Ubuntu 20.04](https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md) & PostgreSQL installed via `apt`
    * [Ubuntu 16.04](https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1604-README.md) & PostgreSQL installed via `apt`
    * [Ubuntu 18.04](https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md) & PostgreSQL docker container
-   * [MacOS 10.15](https://github.com/actions/virtual-environments/blob/master/images/macos/macos-10.15-Readme.md) and PostgreSQL installed via `conda`
+   * [MacOS 12](https://github.com/actions/virtual-environments/blob/master/images/macos/macos-12-Readme.md) and PostgreSQL installed via `conda`
    * [Windows Server 2019](https://github.com/actions/virtual-environments/blob/master/images/win/Windows2019-Readme.md) and PostgreSQL installed via `conda`
  * uses [psycopg2](http://initd.org/psycopg/docs/index.html) to connect if possible
  * can use `sudo` to become the `postgres` UNIX user if necessary/possible (default Ubuntu PostgreSQL setups)

--- a/pgsu/__init__.py
+++ b/pgsu/__init__.py
@@ -347,7 +347,7 @@ def _execute_su_psql(command, dsn, interactive=False):
 
     psql_cmd = [
         'cd ~ && psql {opt} -tc {cmd}'.format(cmd=escape_for_bash(command),
-                                      opt=psql_option_str)
+                                              opt=psql_option_str)
     ]
     sudo_su_psql = sudo_cmd + su_cmd + psql_cmd
 

--- a/pgsu/__init__.py
+++ b/pgsu/__init__.py
@@ -346,7 +346,7 @@ def _execute_su_psql(command, dsn, interactive=False):
     su_cmd = ['su', user, '-c']
 
     psql_cmd = [
-        'psql {opt} -tc {cmd}'.format(cmd=escape_for_bash(command),
+        'cd ~ && psql {opt} -tc {cmd}'.format(cmd=escape_for_bash(command),
                                       opt=psql_option_str)
     ]
     sudo_su_psql = sudo_cmd + su_cmd + psql_cmd

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = pgsu
-version = 0.2.2
+version = 0.2.3
 description = Connect to an existing PostgreSQL cluster as a postgres superuser and execute SQL commands.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,0 @@
-# -*- coding: utf-8 -*-
-"""This file is needed for editable installs (`pip install -e .`).
-
-Can be removed once the following is resolved
-https://github.com/pypa/packaging-problems/issues/256
-"""
-from setuptools import setup
-
-setup()

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+
+# -*- coding: utf-8 -*-
+"""This file is needed for editable installs (`pip install -e .`).
+Can be removed once the following is resolved
+https://github.com/pypa/packaging-problems/issues/256
+"""
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
When `pgsu` tries to become the `postgres` user and run a `psql` command, psql prints a warning [1] that it is not able to change directory (but works nevertheless):

```
WARNING  pgsu:__init__.py:368 could not change directory to "/path/to/c/w/d": Permission denied
```

Since the current implementation routes this to a python logger, this warning is typically not seen by the user unless an exception is raised (or when running tests).
It would be good to fix nevertheless.

[1] https://stackoverflow.com/questions/38470952/postgres-can-not-change-directory-in-ubuntu-14-04