### PR TITLE
Lazy import click to save 10ms of import time

### DIFF
--- a/pgsu/__init__.py
+++ b/pgsu/__init__.py
@@ -201,7 +201,7 @@ def prompt_for_dsn(dsn):
 
     :return: dictionary with the keys: host, port, database, user, password
     """
-    import click
+    import click  # pylint: disable=import-outside-toplevel
     click.echo('Please provide PostgreSQL connection info:')
 
     # Note: Using '' as the prompt default is necessary to allow users to leave the field empty.

--- a/pgsu/__init__.py
+++ b/pgsu/__init__.py
@@ -9,8 +9,6 @@ import os
 from enum import IntEnum
 import subprocess
 
-import click
-
 # By default, try "sudo" only when 'postgres' user exists
 DEFAULT_POSTGRES_UNIX_USER = 'postgres'
 try:
@@ -203,6 +201,7 @@ def prompt_for_dsn(dsn):
 
     :return: dictionary with the keys: host, port, database, user, password
     """
+    import click
     click.echo('Please provide PostgreSQL connection info:')
 
     # Note: Using '' as the prompt default is necessary to allow users to leave the field empty.


### PR DESCRIPTION
I went on a little bit of a rabbit hole of trying to improve the import time of AiiDA.  :sweat_smile: More info here:
https://aiida.discourse.group/t/why-is-aiidalab-base-widget-import-so-slow/32/15

This `pgsu` package is currently always imported (e.g. by simply running `import aiida`). Currently this package brings 'click` by default, which add 10ms of import time, i.e. half of the import time of this package. 

In the grand scheme of things, this obviously doesn't amount much by itself, but combining all the other work I was able to get `import aiida` down to 75ms from the original 300ms. :-)