### PR TITLE
Devops: Update the `conda-incubator/setup-miniconda` action to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,9 +268,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ matrix.python-version }}
+        run-post: false  # https://github.com/conda-incubator/setup-miniconda/issues/280
 
     - name: Install system dependencies
       shell: bash -l {0}


### PR DESCRIPTION
The build on windows was hanging in the post job cleanup.