### PR TITLE
Fix CI, test with Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.12, 3.13]
+        python-version: [3.8, 3.13]
         os: [ubuntu-22.04, ubuntu-24.04]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+    - name: Set up Python 3.11
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.11
 
     - name: Install python dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.12]
+        python-version: [3.8, 3.13]
         os: [ubuntu-22.04, ubuntu-24.04]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 5
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python 3.11
       uses: actions/setup-python@v5
@@ -43,10 +43,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -63,7 +63,7 @@ jobs:
 
     - name: Upload coverage report
       if: github.repository == 'aiidateam/pgsu'
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         name: ubuntu-apt
@@ -82,7 +82,7 @@ jobs:
         postgres-pw: ["testpw"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: CasperWA/postgresql-action@v1.2
       with:
         postgresql version: '10'
@@ -92,7 +92,7 @@ jobs:
         #postgresql auth: trust
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -108,7 +108,7 @@ jobs:
 
     - name: Upload coverage report
       if: github.repository == 'aiidateam/pgsu'
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         name: ubuntu-apt
@@ -139,9 +139,9 @@ jobs:
         options:  --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -158,7 +158,7 @@ jobs:
 
     - name: Upload coverage report
       if: github.repository == 'aiidateam/pgsu'
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         name: ubuntu-postgres-service
@@ -177,10 +177,10 @@ jobs:
       #        python-version: [3.8]
       #
       #    steps:
-      #    - uses: actions/checkout@v3
+      #    - uses: actions/checkout@v4
       #
       #    - name: Set up Python ${{ matrix.python-version }}
-      #      uses: actions/setup-python@v4
+      #      uses: actions/setup-python@v5
       #      with:
       #        python-version: ${{ matrix.python-version }}
       #
@@ -215,10 +215,10 @@ jobs:
         os: ['macos-13', 'windows-2023']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -244,7 +244,7 @@ jobs:
 
     - name: Upload coverage report
       if: github.repository == 'aiidateam/pgsu'
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         name: "${{ matrix.os }}-conda"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
     timeout-minutes: 5
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.11
 
@@ -43,10 +43,10 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -82,7 +82,7 @@ jobs:
         postgres-pw: ["testpw"]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - uses: CasperWA/postgresql-action@v1.2
       with:
         postgresql version: '10'
@@ -92,7 +92,7 @@ jobs:
         #postgresql auth: trust
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -139,9 +139,9 @@ jobs:
         options:  --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -215,10 +215,10 @@ jobs:
         os: ['macos-13', 'windows-2025']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8]
-        os: ['macos-13', 'windows-2023']
+        os: ['macos-13', 'windows-2025']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.13]
+        python-version: [3.8, 3.12, 3.13]
         os: [ubuntu-22.04, ubuntu-24.04]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.13]
+        python-version: [3.8, 3.14]
         os: [ubuntu-22.04, ubuntu-24.04]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,9 @@ name: ci
 
 on: [push, pull_request]
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
 
   pre-commit:
@@ -34,8 +37,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.11]
-        os: [ubuntu-20.04, ubuntu-22.04]
+        python-version: [3.8, 3.12]
+        os: [ubuntu-22.04, ubuntu-24.04]
 
     runs-on: ${{ matrix.os }}
 
@@ -209,7 +212,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.8]
-        os: ['macos-12', 'windows-2022']
+        os: ['macos-13', 'windows-2023']
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/validate_release_tag.py
+++ b/.github/workflows/validate_release_tag.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Validate that the version in the tag label matches the version of the package."""
 # yapf: disable
 import argparse

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,12 @@
 # Install pre-commit hooks via: pre-commit install
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v2.5.0
+  rev: v5.0.0
   hooks:
   - id: double-quote-string-fixer
   - id: end-of-file-fixer
-  - id: fix-encoding-pragma
   - id: mixed-line-ending
   - id: trailing-whitespace
-
-- repo: https://github.com/asottile/setup-cfg-fmt
-  rev: v1.17.0
-  hooks:
-  - id: setup-cfg-fmt
 
 # yapf = yet another python formatter
 - repo: https://github.com/pre-commit/mirrors-yapf
@@ -28,6 +22,6 @@ repos:
   # pylint: static code analysis
   - id: pylint
     name: pylint
-    entry: pylint
+    entry: pylint -s n
     types: [python]
     language: system

--- a/pgsu/__init__.py
+++ b/pgsu/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Connect to an existing PostgreSQL cluster as the `postgres` superuser and execute SQL commands."""
 __version__ = '0.3.0'
 

--- a/pgsu/__init__.py
+++ b/pgsu/__init__.py
@@ -240,7 +240,7 @@ def _try_connect_psycopg(**kwargs):
     try:
         conn = connect(**kwargs)
         success = True
-        conn.close()
+        conn.close()  # pylint: disable=no-member
     except Exception:  # pylint: disable=broad-except
         LOGGER.debug('Unable to connect via psycopg')
         LOGGER.debug(traceback.format_exc())
@@ -261,13 +261,13 @@ def _execute_psyco(command, dsn):
     try:
         conn = psycopg.connect(**dsn)
         conn.autocommit = True
-        with conn.cursor() as cursor:
+        with conn.cursor() as cursor:  # pylint: disable=no-member
             cursor.execute(command)
             if cursor.description is not None:
                 output = cursor.fetchall()
     finally:
         if conn:
-            conn.close()
+            conn.close()  # pylint: disable=no-member
     return output
 
 

--- a/pgsu/cli.py
+++ b/pgsu/cli.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """Commandline interface for pgsu
 
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ classifiers = [
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Programming Language :: Python :: Implementation :: CPython',
 ]
 dependencies = [
@@ -34,7 +36,7 @@ requires-python = '>=3.7'
 [project.optional-dependencies]
 dev = [
     'pre-commit~=3.0',
-    'pylint~=2.5.0',
+    'pylint~=3.2.0',
     'pgtest>=1.3.1',
     'pytest~=8.3.0',
     'pytest-cov'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,10 +33,10 @@ requires-python = '>=3.7'
 
 [project.optional-dependencies]
 dev = [
-    'pre-commit~=2.2',
+    'pre-commit~=3.0',
     'pylint~=2.5.0',
     'pgtest>=1.3.1',
-    'pytest',
+    'pytest~=8.4.0',
     'pytest-cov'
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ classifiers = [
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3 :: Only',
-    'Programming Language :: Python :: 3.7',
     'Programming Language :: Python :: 3.8',
     'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
@@ -31,7 +30,7 @@ dynamic = ['description', 'version']
 license = {file = 'LICENSE'}
 name = 'pgsu'
 readme = 'README.md'
-requires-python = '>=3.7'
+requires-python = '>=3.8'
 
 [project.optional-dependencies]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dev = [
     'pre-commit~=3.0',
     'pylint~=2.5.0',
     'pgtest>=1.3.1',
-    'pytest~=8.4.0',
+    'pytest~=8.0',
     'pytest-cov'
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dev = [
     'pre-commit~=3.0',
     'pylint~=2.5.0',
     'pgtest>=1.3.1',
-    'pytest~=8.0',
+    'pytest~=8.3.0',
     'pytest-cov'
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
     'click',
-    'psycopg[binary]>=3.0,<3.2.4'
+    'psycopg[binary]>=3.0'
 ]
 dynamic = ['description', 'version']
 license = {file = 'LICENSE'}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
     'click',
-    'psycopg[binary]>=3.0'
+    'psycopg[binary]>=3.0,<3.2.4'
 ]
 dynamic = ['description', 'version']
 license = {file = 'LICENSE'}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Programming Language :: Python :: Implementation :: CPython',
 ]
 dependencies = [

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -36,7 +36,7 @@ def test_grant_priv(pgsu, user, database):  # pylint: disable=unused-argument
         'dbname': database,
     }
     conn = psycopg.connect(**dsn)  # pylint: disable=missing-kwoa
-    conn.close()
+    conn.close()  # pylint: disable=no-member
 
 
 @contextmanager


### PR DESCRIPTION
- Drop support for Python 3.7, since we're not testing for it. (we could as well drop support for 3.8, but for now that doesn't seem necessary)
- Test with Python 3.14 and declare it's support. 
- Update GHA runners
- Update pylint to support newer python
- Pin pytest version